### PR TITLE
Pre process

### DIFF
--- a/src/core/image.c
+++ b/src/core/image.c
@@ -11,6 +11,12 @@ Image *create_image(const int width, const int height)
     for (int y = 0; y < height; y++)
     {
         img->pixels[y] = malloc(width * sizeof(Pixel));
+        // init to white
+        for (int x = 0; x < width; x++) {
+            img->pixels[y][x].r = 255;
+            img->pixels[y][x].g = 255;
+            img->pixels[y][x].b = 255;
+        }
     }
 
     return img;

--- a/src/core/image.c
+++ b/src/core/image.c
@@ -22,6 +22,19 @@ Image *create_image(const int width, const int height)
     return img;
 }
 
+void free_image(Image *img)
+{
+    if (img)
+    {
+        for (int y = 0; y < img->height; y++)
+        {
+            free(img->pixels[y]);
+        }
+        free(img->pixels);
+        free(img);
+    }
+}
+
 // get pixel at (x, y) return struct Pixel
 Pixel *get_pixel(const Image *img, const int x, const int y)
 {
@@ -120,13 +133,14 @@ SDL_Surface *image_to_sdl_surface(const Image *img)
 // load a image (bmp, png, jpg..) and convert to custom struc Image to process
 Image *load_image(const char *file)
 {
-    const SDL_Surface *img = IMG_Load(file);
+    SDL_Surface *img = IMG_Load(file);
     if (img == NULL)
     {
         printf("Failed to load the file\n");
         exit(EXIT_FAILURE);
     }
     Image *img_load = sdl_surface_to_image(img, NULL);
+    SDL_FreeSurface(img);
     return img_load;
 }
 
@@ -135,3 +149,4 @@ void export_image(SDL_Surface *surf, const char *file)
 {
     SDL_SaveBMP(surf, file);
 }
+

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -37,6 +37,15 @@ Image *create_image(int width, int height);
 /*<----------------------------->*/
 
 /**
+ * @brief Frees the memory allocated for an image.
+ *
+ * @param img Pointer to the image to free
+ */
+void free_image(Image *img);
+
+/*<----------------------------->*/
+
+/**
  * @brief Retrieves the pixel at position (x, y) in the image.
  *
  * @param img Pointer to the image

--- a/src/pre_process/Makefile
+++ b/src/pre_process/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 CFLAGS = -Wall -Wextra -g `sdl2-config --cflags`
 LDFLAGS = `sdl2-config --libs` -lSDL2_image -lm
 
-SRCS = $(shell find .. -name "*.c")
+SRCS = $(wildcard ../pre_process/*.c ../core/*.c)
 
 OBJS = $(SRCS:.c=.o)
 

--- a/src/pre_process/README.md
+++ b/src/pre_process/README.md
@@ -41,25 +41,54 @@ make clean
 
 ## Usage Examples
 
-Minimal load → grayscale → Sauvola → export:
+Minimal load → scale → export → rotate → grayscale → sauvola → export
+
+Always free resources after use.
 ```c
-#include "core/image.h"
-#include "pre_process/grayscale.h"
-#include "pre_process/rotation.h"
+#include "grayscale.h"
+#include "../core/image.h"
+#include "rotation.h"
+#include "scale.h"
 
-int main(void) {
+int main()
+{
+    SDL_Init(SDL_INIT_VIDEO);
+    IMG_Init(IMG_INIT_PNG);
 
-    Image *img = load_image("input.png");
-    grayscale_image(img);
+    Image *img =
+        load_image("../../resources/pre_process/input/level_1_image_2.png");
 
-    Image *bin = sauvola(img, 15, 128, 0.5f); // block size 15
-    SDL_Surface *surf = image_to_sdl_surface(bin);
-    export_image(surf, "binarized.bmp");
+    Image *scale = resize_image(img, 800, 800, true);
+    free_image(img);
 
-    Image *rot = manual_rotate_image(bin, 15.0);
-    SDL_Surface *rotSurf = image_to_sdl_surface(rot);
-    export_image(rotSurf, "rotated.bmp");
+    SDL_Surface *surf1 = image_to_sdl_surface(scale);
+    export_image(surf1, "scale_output.bmp");
+    SDL_FreeSurface(surf1);  // ✅
 
+    Image *rot = manual_rotate_image(scale, 20);
+    free_image(scale);
+
+    grayscale_image(rot);
+
+    Image *bin = sauvola(rot, 10, 128, 0.07);
+    free_image(rot);
+
+    SDL_Surface *surf2 = image_to_sdl_surface(bin);
+    export_image(surf2, "output.bmp");
+    SDL_FreeSurface(surf2);  // ✅
+
+    // long double *nn_input = malloc(28 * 28 * sizeof(long double));
+    // get_nn_input(bin, nn_input);
+    // for (int i = 0; i < 28 * 28; i++)
+    // {
+    //     printf("%d ", (int)nn_input[i]);
+    // }
+    // printf("\n");
+    free_image(bin);
+    //free(nn_input);  // ✅
+
+    IMG_Quit();
+    SDL_Quit();
     return 0;
 }
 ```
@@ -74,3 +103,37 @@ int main(void) {
 
 Threshold formula: `T = m * (1 + k * ((s / R) - 1))`
 
+## Neural Network Input
+Resize to 28x28 and normalize pixel values to [0, 1]. The function `get_nn_input` take an pre-allocated array of `long double` of size 784 (28*28).
+
+### Example of usage 
+```c
+#include "../core/image.h"
+#include "scale.h"
+
+int main()
+{
+    SDL_Init(SDL_INIT_VIDEO);
+    IMG_Init(IMG_INIT_PNG);
+
+    Image *img =
+        load_image("../../resources/pre_process/input/level_1_image_2.png");
+
+    Image *scale = resize_image(img, 28, 28, true);
+    free_image(img);
+
+    long double *nn_input = malloc(28 * 28 * sizeof(long double));
+    get_nn_input(scale, nn_input);
+    for (int i = 0; i < 28 * 28; i++)
+    {
+        printf("%Lf ", nn_input[i]);
+    }
+    printf("\n");
+    free_image(scale);
+    free(nn_input);  // ✅
+
+    IMG_Quit();
+    SDL_Quit();
+    return 0;
+}
+```

--- a/src/pre_process/debug.c
+++ b/src/pre_process/debug.c
@@ -5,25 +5,42 @@
 
 int main()
 {
+    SDL_Init(SDL_INIT_VIDEO);
+    IMG_Init(IMG_INIT_PNG);
+
     Image *img =
         load_image("../../resources/pre_process/input/level_1_image_2.png");
 
-    Image *scale = resize_image(img, 50, 50, true);
+    Image *scale = resize_image(img, 800, 800, true);
+    free_image(img);
 
-    export_image(image_to_sdl_surface(scale), "scale_output.bmp");
+    SDL_Surface *surf1 = image_to_sdl_surface(scale);
+    export_image(surf1, "scale_output.bmp");
+    SDL_FreeSurface(surf1);  // ✅
 
     Image *rot = manual_rotate_image(scale, 20);
+    free_image(scale);
 
     grayscale_image(rot);
 
     Image *bin = sauvola(rot, 10, 128, 0.07);
+    free_image(rot);
 
-    export_image(image_to_sdl_surface(bin), "output.bmp");
+    SDL_Surface *surf2 = image_to_sdl_surface(bin);
+    export_image(surf2, "output.bmp");
+    SDL_FreeSurface(surf2);  // ✅
 
-    long double *nn_input = get_nn_input(bin);
-    for (int i = 0; i < 28 * 28; i++)
-    {
-        printf("%d ", (int)nn_input[i]);
-    }
-    printf("\n");
+    // long double *nn_input = malloc(28 * 28 * sizeof(long double));
+    // get_nn_input(bin, nn_input);
+    // for (int i = 0; i < 28 * 28; i++)
+    // {
+    //     printf("%d ", (int)nn_input[i]);
+    // }
+    // printf("\n");
+    free_image(bin);
+    //free(nn_input);  // ✅
+
+    IMG_Quit();
+    SDL_Quit();
+    return 0;
 }

--- a/src/pre_process/debug.c
+++ b/src/pre_process/debug.c
@@ -1,17 +1,29 @@
 #include "grayscale.h"
 #include "../core/image.h"
 #include "rotation.h"
+#include "scale.h"
 
 int main()
 {
     Image *img =
-        load_image("../../resources/pre_process/input/level_2_image_2.png");
+        load_image("../../resources/pre_process/input/level_1_image_2.png");
 
-    Image *rot = manual_rotate_image(img, 20);
+    Image *scale = resize_image(img, 50, 50, true);
+
+    export_image(image_to_sdl_surface(scale), "scale_output.bmp");
+
+    Image *rot = manual_rotate_image(scale, 20);
 
     grayscale_image(rot);
 
     Image *bin = sauvola(rot, 10, 128, 0.07);
 
     export_image(image_to_sdl_surface(bin), "output.bmp");
+
+    long double *nn_input = get_nn_input(bin);
+    for (int i = 0; i < 28 * 28; i++)
+    {
+        printf("%d ", (int)nn_input[i]);
+    }
+    printf("\n");
 }

--- a/src/pre_process/rotation.c
+++ b/src/pre_process/rotation.c
@@ -9,10 +9,6 @@ Image *manual_rotate_image(const Image *src, const double angle)
     if (!src)
         return NULL;
 
-    // SDL Init
-    SDL_Init(SDL_INIT_VIDEO);
-    IMG_Init(IMG_INIT_PNG);
-
     // window and renderer (hidden)
     SDL_Window *win =
         SDL_CreateWindow("Hidden", SDL_WINDOWPOS_UNDEFINED,
@@ -20,8 +16,10 @@ Image *manual_rotate_image(const Image *src, const double angle)
     SDL_Renderer *renderer =
         SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
 
+    SDL_Surface *temp_surf = image_to_sdl_surface(src);
     SDL_Texture *tex =
-        SDL_CreateTextureFromSurface(renderer, image_to_sdl_surface(src));
+        SDL_CreateTextureFromSurface(renderer, temp_surf);
+    SDL_FreeSurface(temp_surf);
 
     // angle in radian
     const double rad = angle * M_PI / 180;
@@ -63,7 +61,6 @@ Image *manual_rotate_image(const Image *src, const double angle)
     SDL_FreeSurface(resultSurf);
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(win);
-    SDL_Quit();
 
     return result;
 }

--- a/src/pre_process/rotation.c
+++ b/src/pre_process/rotation.c
@@ -9,7 +9,7 @@ Image *manual_rotate_image(const Image *src, const double angle)
     if (!src)
         return NULL;
 
-    // Init 
+    // SDL Init
     SDL_Init(SDL_INIT_VIDEO);
     IMG_Init(IMG_INIT_PNG);
 
@@ -55,22 +55,7 @@ Image *manual_rotate_image(const Image *src, const double angle)
     // create new Image based on surface
     Image *result = create_image(new_w, new_h);
 
-    for (int y = 0; y < new_h; y++)
-    {
-        for (int x = 0; x < new_w; x++)
-        {
-            Uint8 *pixels = (Uint8 *)resultSurf->pixels;
-            const int bpp = resultSurf->format->BytesPerPixel;
-
-            Uint8 *pPixel = pixels + y * resultSurf->pitch + x * bpp;
-
-            Uint8 r, g, b;
-            SDL_GetRGB(*(Uint32 *)pPixel, resultSurf->format, &r, &g, &b);
-            Pixel p = {r, g, b};
-            set_pixel(result, x, y, &p);
-            // printf("Pixel (%d,%d) = R:%d G:%d B:%d\n", x, y, r, g, b);
-        }
-    }
+    sdl_surface_to_image(resultSurf, result);
 
     // free
     SDL_DestroyTexture(tex);

--- a/src/pre_process/scale.c
+++ b/src/pre_process/scale.c
@@ -98,8 +98,9 @@ void get_nn_input(const Image *img, long double *input)
     for (int j = 0; j < resized->height; j++) {
         for (int i = 0; i < resized->width; i++) {
             const Pixel *p = get_pixel(resized, i, j);
-            // normalize to [0, 1]
-            input[index++] = (long double)(p->r) / 255.0;
+            // Convert to grayscale using standard luminance formula and normalize to [0, 1]
+            long double gray = (0.299 * p->r + 0.587 * p->g + 0.114 * p->b) / 255.0;
+            input[index++] = gray;
         }
     }
     free_image(resized);

--- a/src/pre_process/scale.c
+++ b/src/pre_process/scale.c
@@ -1,0 +1,108 @@
+#include "scale.h"
+
+Image *manual_image_scaling(const Image *src, const float scale_x, const float scale_y)
+{
+    if (!src)
+        return NULL;
+
+    const int new_w = (int)(src->width * scale_x);
+    const int new_h = (int)(src->height * scale_y);
+
+    // SDL Init
+    SDL_Init(SDL_INIT_VIDEO);
+    IMG_Init(IMG_INIT_PNG);
+
+    // window and renderer (hidden)
+    SDL_Window *win =
+        SDL_CreateWindow("Hidden", SDL_WINDOWPOS_UNDEFINED,
+                         SDL_WINDOWPOS_UNDEFINED, 1, 1, SDL_WINDOW_HIDDEN);
+    SDL_Renderer *renderer =
+        SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
+
+    SDL_Texture *tex =
+        SDL_CreateTextureFromSurface(renderer, image_to_sdl_surface(src));
+
+    // texture target
+    SDL_Texture *target =
+        SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888,
+                          SDL_TEXTUREACCESS_TARGET, new_w, new_h);
+    SDL_SetRenderTarget(renderer, target);
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDL_RenderClear(renderer);
+
+
+    const SDL_Rect dstRect = {0, 0, new_w, new_h };
+    // rotate texture using SDL_RenderCopyEx
+    SDL_RenderCopy(renderer, tex, NULL, &dstRect);
+
+    // read pixels from renderer to create new surface
+    SDL_Surface *resultSurf = SDL_CreateRGBSurfaceWithFormat(
+        0, new_w, new_h, 32, SDL_PIXELFORMAT_RGBA8888);
+    SDL_RenderReadPixels(renderer, NULL, SDL_PIXELFORMAT_RGBA8888,
+                         resultSurf->pixels, resultSurf->pitch);
+
+    // create new Image based on surface
+    Image *result = create_image(new_w, new_h);
+
+    sdl_surface_to_image(resultSurf, result);
+
+    // free
+    SDL_DestroyTexture(tex);
+    SDL_DestroyTexture(target);
+    SDL_FreeSurface(resultSurf);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+
+    return result;
+
+}
+
+Image *resize_image_square(const Image *src)
+{
+    const int max = (src->width > src->height) ? src->width : src->height;
+    Image *output = create_image(max, max);
+    const int offset_x = (max - src->width) / 2;
+    const int offset_y = (max - src->height) / 2;
+    for (int i = 0; i < src->width; i++) {
+        for (int j = 0; j < src->height; j++) {
+            Pixel *p = get_pixel(src, i, j);
+            set_pixel(output, i + offset_x, j + offset_y, p);
+        }
+    }
+    return output;
+
+}
+
+Image *resize_image(const Image *src, const int width, const int height, const bool keep_aspect_ratio)
+{
+    if (keep_aspect_ratio) {
+        const Image *square = resize_image_square(src);
+        const float scale_x = (float)width / (float)square->width;
+        const float scale_y = (float)height / (float)square->height;
+        return manual_image_scaling(square, scale_x, scale_y);
+    }
+
+    const float scale_x = (float)width / (float)src->width;
+    const float scale_y = (float)height / (float)src->height;
+    return manual_image_scaling(src, scale_x, scale_y);
+}
+
+long double *get_nn_input(const Image *img)
+{
+    long double *input = malloc(sizeof(long double) * 28 * 28);
+    if (!input) {
+        printf("Memory allocation failed for NN input\n");
+        exit(EXIT_FAILURE);
+    }
+    const Image *resized = resize_image(img, 28, 28, true);
+    int index = 0;
+    for (int j = 0; j < resized->height; j++) {
+        for (int i = 0; i < resized->width; i++) {
+            const Pixel *p = get_pixel(resized, i, j);
+            // normalize to [0, 1]
+            input[index++] = (long double)(p->r) / 255.0;
+        }
+    }
+    return input;
+}

--- a/src/pre_process/scale.c
+++ b/src/pre_process/scale.c
@@ -90,7 +90,7 @@ Image *resize_image(const Image *src, const int width, const int height, const b
 void get_nn_input(const Image *img, long double *input)
 {
     if (!input) {
-        printf("input provided to get_nn_input is NULL\n");
+        printf("Error: input array pointer is NULL in get_nn_input()\n");
         exit(EXIT_FAILURE);
     }
     Image *resized = resize_image(img, 28, 28, true);

--- a/src/pre_process/scale.h
+++ b/src/pre_process/scale.h
@@ -44,14 +44,12 @@ Image *resize_image(const Image *src, int width, int height, bool keep_aspect_ra
 
 
 /**
- * @brief Prepares the input data for a neural network by resizing the image to 28x28 pixels
- *        and normalizing the pixel values.
+ * @brief Converts an image to a format suitable for neural network input.
  *
- * The function resizes the input image to 28x28 pixels, converts each pixel's red channel value
- * to a long double in the range [0, 1], and stores these values in a dynamically allocated array.
- * The caller is responsible for freeing the allocated memory.
+ * The image is resized to 28x28 pixels, and the pixel values are normalized to the range [0, 1].
+ * The resulting pixel values are stored in a provided array.
  *
- * @param img Pointer to the input Image
- * @return long double* Pointer to an array of normalized pixel values (size 784)
+ * @param img   Pointer to the source Image
+ * @param input Pointer to a pre-allocated array of long doubles with at least 784 elements (28*28)
  */
-long double *get_nn_input(const Image *img);
+void get_nn_input(const Image *img, long double *input);

--- a/src/pre_process/scale.h
+++ b/src/pre_process/scale.h
@@ -5,7 +5,7 @@
 #include "../core/image.h"
 
 /**
- * @brief Scales an image to the specified width scake and height using SDL for pixel manipulation.
+ * @brief Scales an image to the specified width scale and height using SDL for pixel manipulation.
  *
  * This function creates a new Image with the desired scale factor and uses SDL to handle the pixel data.
  * @param src     Pointer to the source Image

--- a/src/pre_process/scale.h
+++ b/src/pre_process/scale.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <stdbool.h>
+
+#include "../core/image.h"
+
+/**
+ * @brief Scales an image to the specified width scake and height using SDL for pixel manipulation.
+ *
+ * This function creates a new Image with the desired scale factor and uses SDL to handle the pixel data.
+ * @param src     Pointer to the source Image
+ * @param scale_x Scaling factor in the x direction (width)
+ * @param scale_y Scaling factor in the y direction (height)
+ * @return Image* Pointer to a newly allocated scaled Image
+ */
+Image *manual_image_scaling(const Image *src, float scale_x, float scale_y);
+
+
+/**
+ * @brief Resizes an image to a square shape by adding white padding as needed.
+ *
+ * The resulting image will have dimensions equal to the larger of the width or height of the source image.
+ * The original image is centered within the new square image, and any extra space is filled with white pixels.
+ *
+ * @param src Pointer to the source Image
+ * @return Image* Pointer to a newly allocated square Image
+ */
+Image *resize_image_square(const Image *src);
+
+/**
+ * @brief Resizes an image to the specified width and height, optionally maintaining the aspect ratio.
+ *
+ * If `keep_aspect_ratio` is true, the image is first resized to a square shape by adding white padding,
+ * and then scaled to fit within the specified dimensions while preserving the original aspect ratio.
+ * If false, the image is directly scaled to the specified width and height, which may distort the image.
+ *
+ * @param src                 Pointer to the source Image
+ * @param width               Desired width of the output image
+ * @param height              Desired height of the output image
+ * @param keep_aspect_ratio   Boolean flag to indicate whether to maintain the aspect ratio
+ * @return Image* Pointer to a newly allocated resized Image
+ */
+Image *resize_image(const Image *src, int width, int height, bool keep_aspect_ratio);
+
+
+/**
+ * @brief Prepares the input data for a neural network by resizing the image to 28x28 pixels
+ *        and normalizing the pixel values.
+ *
+ * The function resizes the input image to 28x28 pixels, converts each pixel's red channel value
+ * to a long double in the range [0, 1], and stores these values in a dynamically allocated array.
+ * The caller is responsible for freeing the allocated memory.
+ *
+ * @param img Pointer to the input Image
+ * @return long double* Pointer to an array of normalized pixel values (size 784)
+ */
+long double *get_nn_input(const Image *img);


### PR DESCRIPTION
This pull request introduces significant improvements to image memory management, adds new image scaling and resizing features, and updates documentation and usage examples to promote correct resource handling. The main changes include implementing a proper `free_image` function, providing new scaling utilities for neural network preprocessing, and ensuring that all dynamically allocated resources are freed appropriately in both code and documentation.

**Memory management and resource handling:**

* Added a `free_image` function to properly deallocate memory for `Image` structures, and updated the header file `image.h` with documentation for this function. Usage of `free_image` is now shown in all examples and test code. [[1]](diffhunk://#diff-06ece9f8e7bcdb0772bbccfb27a79a3dc4d7c1a959200e5b04501f61e2af835cR14-R37) [[2]](diffhunk://#diff-6ce242ea1ae509699d9b885a33b8d85757a286c08a1915a174231d1082d0cd8bR39-R47)
* Updated image loading and rotation code to ensure all SDL surfaces and textures are freed, and removed unnecessary calls to `SDL_Quit` from image manipulation functions to prevent premature SDL shutdown. [[1]](diffhunk://#diff-06ece9f8e7bcdb0772bbccfb27a79a3dc4d7c1a959200e5b04501f61e2af835cL117-R143) [[2]](diffhunk://#diff-4ee83869cc155dbe7c66d42626194ad527fbca75e5974f39a7ee2b14b0090086L12-R22) [[3]](diffhunk://#diff-4ee83869cc155dbe7c66d42626194ad527fbca75e5974f39a7ee2b14b0090086L58-L81)

**Image scaling and neural network preprocessing:**

* Added a new `scale.c` module with functions for manual image scaling (`manual_image_scaling`), resizing to a square with padding (`resize_image_square`), resizing with optional aspect ratio preservation (`resize_image`), and extracting normalized neural network input (`get_nn_input`). The corresponding header file `scale.h` was also added with detailed documentation. [[1]](diffhunk://#diff-6c877cf6d14ce333b882380a9d8e32e2e2af351fd8483252574e4602915d862fR1-R106) [[2]](diffhunk://#diff-869a67b9c8e2ffb758e5066d43f5cda71c74e10fd2d2a00242ec232eb3dfd9c5R1-R55)
* Updated the Makefile to explicitly include new scaling source files.

**Documentation and usage examples:**

* Overhauled the `README.md` usage examples to demonstrate proper resource management (including freeing images and SDL surfaces), and added a dedicated section and example for neural network input preparation. [[1]](diffhunk://#diff-5120d24c5e8da1e6781675292e2ac07e84fb34525814a34df2a2fce31f8f9508L44-R91) [[2]](diffhunk://#diff-5120d24c5e8da1e6781675292e2ac07e84fb34525814a34df2a2fce31f8f9508R106-R139)
* Updated the debug/test code to use the new scaling functions and follow best practices for initialization and cleanup.

These changes collectively improve the safety, flexibility, and clarity of the image processing codebase, making it easier to use and extend for further image analysis and neural network applications.